### PR TITLE
Sawec wp5 v9.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@
 /Runs/referentie/Desktops/Default.dms
 /SubWCRevData.str
 Runs/HestiaRun.dms
+/.vs/SawecWP5/FileContentIndex
+/.vs

--- a/model/Classifications.dms
+++ b/model/Classifications.dms
@@ -1478,7 +1478,7 @@ container Classifications: Using = "Units", KeepData = "True", IsHidden = "True"
 			attribute<string> LabelBouwjaar   := BouwjaarWoningRapportage/Label[nr_2];
 			attribute<string> Label           := LabelWoningtype + '_' + LabelBouwjaar;
 		}
-
+/* REMOVE, NOT USED
 		unit<uint32> PeriodeWonen := combine(Periode, WoningtypeNieuwbouw) // wordt gebruikt om Nieuwbouw maps en ResterdFactorMaps te lezen.
 		{
 			attribute<bool>                hasNieuwbouw            := Periode/hasNieuwbouw[nr_1];
@@ -1496,14 +1496,14 @@ container Classifications: Using = "Units", KeepData = "True", IsHidden = "True"
 
 			container V := for_each_nedv(name, 'value('+string(id(.))+', ...)', void, .);
 		}
-
+END REMOVE */
 		unit<uint8> UtiltypeBouwjaarBestaand := combine_uint8(UtiltypeBestaand, BouwjaarUtilBestaand)
 		{
 			attribute<string> LabelUtiltype := UtiltypeBestaand/label[nr_1];
 			attribute<string> LabelBouwjaar   := BouwjaarUtilBestaand/label[nr_2];
 			attribute<string> label           := LabelUtiltype + '_' + LabelBouwjaar;
 		}
-
+/* REMOVE, NOT USED
 		unit<uint32> PeriodeUtiliteit := combine(Periode, UtilTypeNieuwbouw)
 		{
 			attribute<bool>                hasNieuwbouw            := Periode/hasNieuwbouw[nr_1];
@@ -1519,5 +1519,6 @@ container Classifications: Using = "Units", KeepData = "True", IsHidden = "True"
 			attribute<string>              prev_name               := prev_Periode_name + '/' + utiliteit_Name;
 			attribute<string>              label                   := name;
 		}
+END REMOVE */
 	}
 }

--- a/model/stam/CalculationSchemes/BebouwingsOperaties.dms
+++ b/model/stam/CalculationSchemes/BebouwingsOperaties.dms
@@ -38,7 +38,7 @@ container BebouwingsOperaties
 		unit<uint32> Nieuwbouw;
 		// end case parameters
 
-		unit<uint16> ModelObjectKeyDomein : ishidden = "True";
+		unit<uint16> ModelObjectKeyDomein := Bestaand/ModelObjectKeyDomein, ishidden = "True";
 
 		unit<uint32> result := union_unit(Bestaand, Nieuwbouw)
 		,	DialogType = "Map"

--- a/model/stam/CalculationSchemes/StartingStateComponent.dms
+++ b/model/stam/CalculationSchemes/StartingStateComponent.dms
@@ -297,8 +297,8 @@ template StartingStateComponent
 		// =============== attributen die ook per GebiedOptie kunnen wijzigen
 		attribute<Classifications/WarmteOptie> WarmteOptie_rel := Classifications/GebouwOptie/WarmteOptie_rel [ GebouwOptie_rel ];		
 	}
-	unit<uint16> ModelObjectKeyDomein;
-	unit<uint32>   PreStartJaar := subset(Results/bouwjaar < Startjaar_jaar)
+	unit<uint16> ModelObjectKeyDomein := combine_unit_uint16(BebouwingsTypeDomein, Classifications/combines/BE);
+	unit<uint32> PreStartJaar := subset(Results/bouwjaar < Startjaar_jaar)
 	{
 		unit<uint32> buurt         := Invoer/RuimtelijkeData/StudieGebied/buurt;
 		unit<uint32> Aflevergebied := Invoer/RuimtelijkeData/BestaandeWarmtenetten/Aflevergebied_data;

--- a/model/stam/CalculationSchemes/StartingStateComponent.dms
+++ b/model/stam/CalculationSchemes/StartingStateComponent.dms
@@ -297,7 +297,7 @@ template StartingStateComponent
 		// =============== attributen die ook per GebiedOptie kunnen wijzigen
 		attribute<Classifications/WarmteOptie> WarmteOptie_rel := Classifications/GebouwOptie/WarmteOptie_rel [ GebouwOptie_rel ];		
 	}
-	unit<uint16> ModelObjectKeyDomein := combine_unit_uint16(BebouwingsTypeDomein, Classifications/combines/BE);
+	unit<uint16> ModelObjectKeyDomein := ModelObject/ModelObjectKeyDomein;
 	unit<uint32> PreStartJaar := subset(Results/bouwjaar < Startjaar_jaar)
 	{
 		unit<uint32> buurt         := Invoer/RuimtelijkeData/StudieGebied/buurt;

--- a/model/stam/CalculationSchemes/TussenResultaten/BebouwingsComponentT.dms
+++ b/model/stam/CalculationSchemes/TussenResultaten/BebouwingsComponentT.dms
@@ -18,7 +18,7 @@ template BebouwingsComponentT
 	parameter<Classifications/BebouwingsSectorBase> BcSector :=	rlookup(BCname, Classifications/BebouwingsSectorBase/name), ishidden = "True";
 	
 	unit<uint32> PrevObject := ='PrevState/Bebouwing/'+ BCname, ishidden = "True";
-	unit<uint16> ModelObjectKeyDomein : ishidden = "true";
+	unit<uint16> ModelObjectKeyDomein := ModelObject/ModelObjectKeyDomein, ishidden = "true";
 
 	unit<uint32> BeginSituatieResults := = 'BeginSituatie/StartingStateComponenten/'+ BCname +'/Results', ishidden = "True"
 	{

--- a/model/stam/CalculationSchemes/TussenResultaten/BebouwingsComponentT/ActieveWoning.dms
+++ b/model/stam/CalculationSchemes/TussenResultaten/BebouwingsComponentT/ActieveWoning.dms
@@ -11,11 +11,11 @@
 //////////////////////////////////////////////////////////////////////////////////////////
 
 //====== Berekeningen voor woningen die actief zijn op minimaal één functioneel product =====
-unit<uint32> ActieveWoning := select_orgrel(BO/Activatie/ProductActief || BO/Activatie/BouwdeelActief)
+unit<uint32> ActieveWoning := select_with_org_rel(BO/Activatie/Actief_conditie)
 {		
 	attribute<BO> BO_rel := org_rel, ishidden = "True";
-	attribute<rdc_meter> Geometry := select_data(ActieveWoning, BO/Geometry), ishidden = "True";
-	attribute<ActieveWoning> per_BO(BO) := invert(BO_rel), ishidden = "True";
+	attribute<rdc_meter> Geometry := collect_by_cond(ActieveWoning, BO/Activatie/Actief_conditie, BO/Geometry), ishidden = "True";
+//REMOVE, NOT USED	attribute<ActieveWoning> per_BO(BO) := invert(BO_rel), ishidden = "True";
 	
 	unit<uint32> xInvesteringsOptie := union_unit(ProductActieveWoning/xIsolatieAmbitie/PAW_xInvesteringsOptie, BouwdeelActieveWoning/ProductInactieveAmbitie)
 	{
@@ -174,8 +174,8 @@ unit<uint32> ActieveWoning := select_orgrel(BO/Activatie/ProductActief || BO/Act
 	}
 	container Choice_Per_BO : ishidden = "True"
 	{
-		attribute<xInvesteringsOptie> xInvesteringsOptie_rel (BO) := Choice_per_ActieveWoning/xInvesteringsOptie_rel[per_BO];
-		attribute<GeschikteOptie>     GeschikteOptie_rel     (BO) := Choice_per_ActieveWoning/GeschikteOptie_rel[per_BO];
+		attribute<xInvesteringsOptie> xInvesteringsOptie_rel (BO) := recollect_by_cond(BO/Activatie/Actief_conditie, Choice_per_ActieveWoning/xInvesteringsOptie_rel);
+		attribute<GeschikteOptie>     GeschikteOptie_rel     (BO) := recollect_by_cond(BO/Activatie/Actief_conditie, Choice_per_ActieveWoning/GeschikteOptie_rel);
 	}
 	
 	unit<uint32> BebouwingsObjectMetGebouwOptie := BO

--- a/model/stam/CalculationSchemes/TussenResultaten/BebouwingsComponentT/Activatie.dms
+++ b/model/stam/CalculationSchemes/TussenResultaten/BebouwingsComponentT/Activatie.dms
@@ -157,6 +157,7 @@ container Activatie
 		'const(false,..)';
 	attribute<bool> BouwdeelActief     (..) := =RekenStapName == 'StartJaar' ? 'const(false,..)' : 'BouwdeelVervanging && not(KanNietActiveren)';
 	attribute<bool> ProductActief      (..) := =RekenStapName == 'StartJaar' ? 'const(false,..)' : 'ProductVervanging  && not(KanNietActiveren)';
+	attribute<bool> Actief_conditie    (..) := BouwdeelActief || ProductActief;
 
 	attribute<classifications/Uitvoering> Uitvoering (..) := switch(
 		  case(AND(Bouwdelen/RenovatieMoment, IsMeergezins                                                     ), Classifications/Uitvoering/V/Nat_Mgw_Prj)


### PR DESCRIPTION
Hoi Folckert, 

ik ben [GeoDms v.9.0.0.](https://github.com/ObjectVision/GeoDMS/releases/tag/v9.0.0) met deze wijzigingen (zie ook de SAWEC-WP5-v9.0.0 branch) aan het testen. 
- v9.0.0. is iets strenger is met categorische values, waartoe aanpassingen m.b.t. combine_unit en combine_data in ModelObjectKey nodig waren, mede t.b.v. user experience.
- de recollect_by_cond functie voor het terugzetten van activeValues o.b.v. activeCondition is toegepast. Ik ben voornemens met 9.0.0 binnenkort nog eens verder naar performance en mogelijke verbeteringen te kijken. 

Overigens zag ik dat momenteel IntegrityCheck faalt van /TussenResultaten/R1_2021/BebouwingsComponenten/Woning/BO/Energielabel_rel 
ik vermoed Work In Progress, ik zag dat /Invoer/RuimtelijkeData/Vastgoed/NieuwbouwObjecten/Y2021_Y2030/BebouwingsObject/ModelObject_rel verwijst naar een modelobject uit Bouwjaarklasse 2021...2030 waardoor de rlookup( [ModelObjectKey ](dms:dp.general:/Invoer/RuimtelijkeData/Vastgoed/NieuwbouwObjecten/Y2021_Y2030/BebouwingsObject/ModelObjectKey), [Kengetallen/Bebouwing/Woning/Results/ModelObjectKey ](dms:dp.general:/Invoer/Kengetallen/Bebouwing/Woning/Results/ModelObjectKey)) null levert.

Kunnen we binnenkort even overleggen of het zinvol is om:
- weer naar performance te kijken, 
- wat jullie aandacht heeft (ook qua user experience) en 
- wat een goede branch/revisie is om mee te testen?

Groet,
Maarten.